### PR TITLE
BigInts for all the things

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ If no errors were encountered, `errors` will be `null`. If errors were encounter
 
 This method is great if you want to implement custom logic based on the errors that were encountered.
 
-### `getFolderSize.loose(path, [options]): number`
+### `getFolderSize.loose(path, [options]): number | bigint`
 The `loose` method will return the folder size directly and ignore any errors it encounters, which means the returned folder size could be smaller than the real folder size.
 
 This method is great if the precise size isn't too important, for example when used only to display the folder size to the user.
 
-### `getFolderSize.strict(path, [options]): number`
+### `getFolderSize.strict(path, [options]): number | bigint`
 The `strict` method will return the folder size directly, but throw an error if it encounters any read errors.
 
 This method is great if you need a very accurate number. You will have to implement some sort of error handling to use it reliably.
@@ -63,11 +63,14 @@ Any of the three methods can also take an `options` object:
 getFolderSize(
   '/path/to/folder', 
   {
+    bigint: true,
     ignore: /pattern/,
     fs: customFS,
   }
 )
 ```
+
+If the `bigint` option is set to true, the folder size is returned as a BigInt instead of the default Number.
 
 The `ignore` option takes a regex pattern. Any file or folder with a path that matches the pattern will not be counted in the total folder size.
 

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ async function core (rootItemPath, options = {}, returnType = {}) {
   async function processItem(itemPath) {
     if(options.ignore?.test(itemPath)) return;
 
-    const stats = returnType.strict ? await fs.lstat(itemPath) : await fs.lstat(itemPath).catch(error => errors.push(error));
+    const stats = returnType.strict ? await fs.lstat(itemPath, {bigint: true}) : await fs.lstat(itemPath, {bigint: true}).catch(error => errors.push(error));
     if(typeof stats !== 'object') return;
     fileSizes.set(stats.ino, stats.size);
 

--- a/index.js
+++ b/index.js
@@ -6,12 +6,13 @@ import { join as joinPaths } from 'path';
  * 
  * If any errors are returned, the returned folder size is likely smaller than the real folder size.
  * 
- * @param {string} itemPath         - Path of the folder.
- * @param {object} [options]        - Options.
- * @param {object} [options.ignore] - If a file's path matches this regex object, its size is not counted.
- * @param {object} [options.fs]     - The filesystem that should be used. Uses node fs by default.
+ * @param {string}  itemPath         - Path of the folder.
+ * @param {object}  [options]        - Options.
+ * @param {boolean} [options.bigint] - Should the folder size be returned as a BigInt instead of a Number.
+ * @param {object}  [options.ignore] - If a file's path matches this regex object, its size is not counted.
+ * @param {object}  [options.fs]     - The filesystem that should be used. Uses node fs by default.
  * 
- * @returns {Promise<{size: number, errors: Array<Error> | null}>} - An object containing the size of the folder in bytes and a list of encountered errors.
+ * @returns {Promise<{size: number | bigint, errors: Array<Error> | null}>} - An object containing the size of the folder in bytes and a list of encountered errors.
  */
 export default async function getFolderSize (itemPath, options) { return await core(itemPath, options, {errors: true}) }
 
@@ -20,12 +21,13 @@ export default async function getFolderSize (itemPath, options) { return await c
  * 
  * The returned folder size might be smaller than the real folder size. It is impossible to know for sure, since errors are ignored.
  * 
- * @param {string} itemPath         - Path of the folder.
- * @param {object} [options]        - Options.
- * @param {object} [options.ignore] - If a file's path matches this regex object, its size is not counted.
- * @param {object} [options.fs]     - The filesystem that should be used. Uses node fs by default.
+ * @param {string}  itemPath         - Path of the folder.
+ * @param {object}  [options]        - Options.
+ * @param {boolean} [options.bigint] - Should the folder size be returned as a BigInt instead of a Number.
+ * @param {object}  [options.ignore] - If a file's path matches this regex object, its size is not counted.
+ * @param {object}  [options.fs]     - The filesystem that should be used. Uses node fs by default.
  * 
- * @returns {Promise<number>} - The size of the folder in bytes.
+ * @returns {Promise<number | bigint>} - The size of the folder in bytes.
  */
 getFolderSize.loose = async (itemPath, options) => await core(itemPath, options);
 
@@ -34,12 +36,13 @@ getFolderSize.loose = async (itemPath, options) => await core(itemPath, options)
  * 
  * Because errors will otherwise make this method fail, the returned folder size will always be accurate.
  * 
- * @param {string} itemPath         - Path of the folder.
- * @param {object} [options]        - Options.
- * @param {object} [options.ignore] - If a file's path matches this regex object, its size is not counted.
- * @param {object} [options.fs]     - The filesystem that should be used. Uses node fs by default.
+ * @param {string}  itemPath         - Path of the folder.
+ * @param {object}  [options]        - Options.
+ * @param {boolean} [options.bigint] - Should the folder size be returned as a BigInt instead of a Number.
+ * @param {object}  [options.ignore] - If a file's path matches this regex object, its size is not counted.
+ * @param {object}  [options.fs]     - The filesystem that should be used. Uses node fs by default.
  * 
- * @returns {Promise<number>} - The size of the folder in bytes.
+ * @returns {Promise<number | bigint>} - The size of the folder in bytes.
  */
 getFolderSize.strict = async (itemPath, options) => await core(itemPath, options, {strict: true});
 
@@ -71,7 +74,19 @@ async function core (rootItemPath, options = {}, returnType = {}) {
     }
   }
 
-  const folderSize = Array.from(fileSizes.values()).reduce((total, fileSize) => total + fileSize, 0);
+  let folderSize = Array.from(fileSizes.values()).reduce((total, fileSize) => total + fileSize, 0n);
+  
+  if(!options.bigint) {
+    if(folderSize > BigInt(Number.MAX_SAFE_INTEGER)){
+      const error = new RangeError('The folder size is too large to return as a Number. You can instruct this package to return a BigInt instead.');
+      if(returnType.strict){
+        throw error;
+      }else{
+        errors.push(error);
+      }
+    }
+    folderSize = Number(folderSize);
+  }
 
   if (returnType.errors) {
     return {

--- a/test/logic.js
+++ b/test/logic.js
@@ -106,21 +106,21 @@ const badFSCore = Volume.fromJSON(
 ).promisesApi;
 
 const badFS = {
-  lstat: async (itemPath) => {
+  lstat: async (itemPath, options) => {
     if(itemPath.includes('failFile')){
       throw Error('Nah - File');
     }else{
-      return await badFSCore.lstat(itemPath);
+      return await badFSCore.lstat(itemPath, options);
     }
   },
-  readdir: async (itemPath) => {
+  readdir: async (itemPath, options) => {
     if(itemPath.includes('failDir')){
       throw Error('Nah - Directory');
     }else{
-      return await badFSCore.readdir(itemPath);
+      return await badFSCore.readdir(itemPath, options);
     }
   }
-}
+};
 
 tap.test('error handling', async () => {
 


### PR DESCRIPTION
This PR is two-fold:

## Use BigInts for ino IDs
As reported in #21, using Numbers for ino IDs is dangerous, because real ino IDs are 64-bit and can overflow the 32-bit Numbers, which can make the program believe that two different files are the same file, and then only count the size of one of them.

This change is theoretically just a minor fix, but if anyone uses a custom filesystem, it now has to support BigInts, which it did not have to do previously. Therefore, I think we should release this as v4.0.0 to avoid possible breakage.

Fixes #21

## Support folder size output as BigInt
This change is arguably less important, and yet much more complex. It allows the user to choose that the size of the folder is returned as a BigInt. This is only necessary if you are working with crazy large folders, but there can be other practical reasons that you'd want the output as a BigInt.
It's a pretty common feature in other node libraries, and is also modeled to work the same way as other libraries, such as `fs`.