### PR TITLE
If file is asar, then stats.size is int

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ async function core(rootItemPath, options = {}, returnType = {}) {
 					.lstat(itemPath, { bigint: true })
 					.catch((error) => errors.push(error));
 		if (typeof stats !== "object") return;
-		if (!foundInos.has(stats.ino)) {
+		if (!foundInos.has(stats.ino) && typeof stats.size === "bigint") {
 			foundInos.add(stats.ino);
 			folderSize += stats.size;
 		}


### PR DESCRIPTION
`
TypeError: Cannot mix BigInt and other types, use explicit conversions
`

If file is asar, then `stats.size` is integer (https://github.com/electron/electron/blob/main/lib/node/asar-fs-wrapper.ts#L127-L142)

![2025-06-19 14 45 42](https://github.com/user-attachments/assets/fb24465f-f0d9-422c-a0c0-4b5b2d20b18f)

@atjn 
